### PR TITLE
Display message timestamps in browser time

### DIFF
--- a/apps/web/components/local-time.tsx
+++ b/apps/web/components/local-time.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { buildPostTimeValues } from '@/utils/datetime'
+
+type LocalTime = {
+  text: string
+  shortText: string
+}
+
+function useLocalTime(date: Date) {
+  const [localTime, setLocalTime] = useState<LocalTime | null>(null)
+  useEffect(() => setLocalTime(buildPostTimeValues(date)), [date])
+  return localTime
+}
+
+export const DisplayLocalTime = ({
+  short,
+  dateStr,
+}: {
+  short?: boolean
+  dateStr: string
+}) => {
+  const localTime = useLocalTime(new Date(dateStr))
+  if (!localTime) return <span className="invisible">{dateStr}</span>
+  return (
+    <span className="visible">
+      {short ? localTime.shortText : localTime.text}
+    </span>
+  )
+}

--- a/apps/web/components/message.tsx
+++ b/apps/web/components/message.tsx
@@ -1,5 +1,6 @@
 import { buildPostTimeValues } from '@/utils/datetime'
 import { parseDiscordMessage } from '@/utils/discord-markdown'
+import { DisplayLocalTime } from './local-time'
 import 'highlight.js/styles/github-dark-dimmed.css'
 
 export type Attachment = {
@@ -44,7 +45,7 @@ export const Message = ({
               dateTime={createdAtTimes.iso}
               title={createdAtTimes.tooltip}
             >
-              {createdAtTimes.shortText}
+              <DisplayLocalTime short dateStr={createdAt.toISOString()} />
             </time>
           )}
         </div>
@@ -60,7 +61,7 @@ export const Message = ({
                 dateTime={createdAtTimes.iso}
                 title={createdAtTimes.tooltip}
               >
-                {createdAtTimes.text}
+                <DisplayLocalTime dateStr={createdAt.toISOString()} />
               </time>
             </div>
           )}


### PR DESCRIPTION
At the moment all message timestamps are displayed in UTC which is the server timezone. This PR aims to display all timestamps in user browser timezone.