### PR TITLE
Align message timestamps at the top of the message

### DIFF
--- a/apps/web/components/message.tsx
+++ b/apps/web/components/message.tsx
@@ -24,7 +24,7 @@ export const Message = ({
 
   return (
     <div id={`message-${snowflakeId}`} className="group ">
-      <div className="flex pt-16 -mt-16 pointer-events-none [&>*]:pointer-events-auto">
+      <div className="flex flex-row items-start pointer-events-none [&>*]:pointer-events-auto">
         <div className="flex justify-start items-start w-[50px] sm:w-[60px] shrink-0">
           {isFirstRow ? (
             <img


### PR DESCRIPTION
Before:

<img width="687" alt="image" src="https://github.com/rafaelalmeidatk/nextjs-forum/assets/44609036/0f0275f8-ba00-4aa4-97b9-21f88db595c1">

---

After:

<img width="684" alt="image" src="https://github.com/rafaelalmeidatk/nextjs-forum/assets/44609036/80bc235f-64d3-4905-880c-b65bd3eb02a1">

---

This PR also removed a mysterious `pt-16 -mt-16` which causes a bug where if you hover on the gap between messages such that the mouse is within this 64px padding, you can trigger the timestamp to be displayed when you don't expect it (the little red strip at the top in the following screenshot)

https://github.com/rafaelalmeidatk/nextjs-forum/blob/fac4fb283f6976c3f88f5f85399c6f9f32edbaeb/apps/web/components/message.tsx#L27

<img width="711" alt="image" src="https://github.com/rafaelalmeidatk/nextjs-forum/assets/44609036/d591e119-0f6c-4f00-9cfb-b335acfe18c0">
