### PR TITLE
fix: make entire post clickable

### DIFF
--- a/apps/web/components/post.tsx
+++ b/apps/web/components/post.tsx
@@ -26,7 +26,7 @@ export const Post = ({
   const borderColor = hasAnswer ? 'border-green-700' : 'border-neutral-700'
 
   return (
-    <Link href={`/post/${id}`}>
+    <Link href={`/post/${id}`} className='mb-[4px]'>
       <div className={`px-4 py-3 border bg-neutral-800 ${borderColor} rounded hover:opacity-75`}>
         <p className="text-white inline-block pr-2 text-lg font-semibold hover:opacity-75">
           {title}

--- a/apps/web/components/post.tsx
+++ b/apps/web/components/post.tsx
@@ -26,34 +26,33 @@ export const Post = ({
   const borderColor = hasAnswer ? 'border-green-700' : 'border-neutral-700'
 
   return (
-    <div className={`px-4 py-3 border bg-neutral-800 ${borderColor} rounded`}>
-      <Link
-        className="text-white inline-block pr-2 text-lg font-semibold hover:opacity-75 hover:no-underline"
-        href={`/post/${id}`}
-      >
-        {title}
-      </Link>
+    <Link href={`/post/${id}`}>
+      <div className={`px-4 py-3 border bg-neutral-800 ${borderColor} rounded hover:opacity-75`}>
+        <p className="text-white inline-block pr-2 text-lg font-semibold hover:opacity-75">
+          {title}
+        </p>
 
-      <div className="mt-2 flex items-center space-x-2">
-        <img
-          src={author.avatar}
-          alt={`${author.username}'s avatar`}
-          className="rounded-full w-5 h-5"
-        />
-        <div className="text-sm opacity-90">
-          {author.username} asked on{' '}
-          <time dateTime={createdAtTimes.iso} title={createdAtTimes.tooltip}>
-            {createdAtTimes.text}
-          </time>{' '}
-          · {messagesCount} {plur('Message', messagesCount)}
-          {hasAnswer && (
-            <span>
-              {' '}
-              · <span className="font-semibold text-green-500">Answered</span>
-            </span>
-          )}
+        <div className="mt-2 flex items-center space-x-2">
+          <img
+            src={author.avatar}
+            alt={`${author.username}'s avatar`}
+            className="rounded-full w-5 h-5"
+          />
+          <div className="text-sm opacity-90">
+            {author.username} asked on{' '}
+            <time dateTime={createdAtTimes.iso} title={createdAtTimes.tooltip}>
+              {createdAtTimes.text}
+            </time>{' '}
+            · {messagesCount} {plur('Message', messagesCount)}
+            {hasAnswer && (
+              <span>
+                {' '}
+                · <span className="font-semibold text-green-500">Answered</span>
+              </span>
+            )}
+          </div>
         </div>
       </div>
-    </div>
+    </Link>
   )
 }

--- a/apps/web/components/post.tsx
+++ b/apps/web/components/post.tsx
@@ -27,7 +27,7 @@ export const Post = ({
 
   return (
     <Link href={`/post/${id}`} className='block text-white no-underline'>
-      <div className={`px-4 py-3 border bg-neutral-800 ${borderColor} rounded hover:opacity-75`}>
+      <div className={`px-4 py-3 border bg-neutral-800 ${borderColor} rounded hover:opacity-90`}>
         <p className="text-white inline-block pr-2 text-lg font-semibold">
           {title}
         </p>

--- a/apps/web/components/post.tsx
+++ b/apps/web/components/post.tsx
@@ -26,9 +26,9 @@ export const Post = ({
   const borderColor = hasAnswer ? 'border-green-700' : 'border-neutral-700'
 
   return (
-    <Link href={`/post/${id}`} className='mb-[4px]'>
+    <Link href={`/post/${id}`} className='block text-white no-underline'>
       <div className={`px-4 py-3 border bg-neutral-800 ${borderColor} rounded hover:opacity-75`}>
-        <p className="text-white inline-block pr-2 text-lg font-semibold hover:opacity-75">
+        <p className="text-white inline-block pr-2 text-lg font-semibold">
           {title}
         </p>
 

--- a/apps/web/components/post.tsx
+++ b/apps/web/components/post.tsx
@@ -38,7 +38,7 @@ export const Post = ({
             alt={`${author.username}'s avatar`}
             className="rounded-full w-5 h-5"
           />
-          <div className="text-sm opacity-90">
+          <div className="text-sm opacity-90 no-underline">
             {author.username} asked on{' '}
             <time dateTime={createdAtTimes.iso} title={createdAtTimes.tooltip}>
               {createdAtTimes.text}


### PR DESCRIPTION
## Scope
Before only the titles of each post were clickable
With this update the entire post is clickable

## Changes made
- Wrapped the post component with a `<Link />` instead of just the title
- Added `hover:opacity-75` to the styling on the entire div (same hover style update that is applied to the title)