### PR TITLE
Add Q&A structured data for SEO

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "autoprefixer": "^10.4.14",
     "eslint": "8.36.0",
     "postcss": "^8.4.21",
+    "schema-dts": "^1.1.2",
     "tailwindcss": "^3.2.7",
     "typescript": "^5.0.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2869,6 +2869,11 @@ scheduler@^0.23.0:
   dependencies:
     loose-envify "^1.1.0"
 
+schema-dts@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/schema-dts/-/schema-dts-1.1.2.tgz#82ccf71b5dcb80065a1cc5941888507a4ce1e44b"
+  integrity sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==
+
 semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"


### PR DESCRIPTION
This follows Google's specification on how to implement [Q&A structured data](https://developers.google.com/search/docs/appearance/structured-data/qapage) which also meant using [JSON-LD](https://nextjs.org/docs/app/building-your-application/optimizing/metadata#json-ld). I didn't add the other replies to suggested answers because comments like "thanks for the reply" (or something else generic) won't be any help. I added this to the same level as `LayoutWithSidebar` so that it is the highest up as possible in the element tree (currently its parent is body). The [schema-dts](https://www.npmjs.com/package/schema-dts) package was also added (as dev dependency) to include typing.

Closes #26 

Note: It looks like I modified more code in the return statement, but I only added `<> </>` as well as indenting everything (to have the JSON-LD as high as possible).