### PR TITLE
Add lastmod to sitemap

### DIFF
--- a/apps/web/utils/datetime.ts
+++ b/apps/web/utils/datetime.ts
@@ -26,3 +26,7 @@ export const buildPostTimeValues = (createdAt: Date) => {
 
   return { text, shortText, tooltip, iso }
 }
+
+export const largerDate = (...dates: Date[]) => {
+  return dates.reduce((a, b) => (a > b ? a : b))
+}


### PR DESCRIPTION
As Google likes the `lastmod` property in [sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/large-sitemaps), this PR adds it. The method that I have chosen is get the most recent message (including edits) in the post, and then display that. I am not sure about the performance of doing this, so if you want I can make adding/updating posts modify the post's `editedAt` (or make a new property).