### PR TITLE
Sync user when changing the username/avatar and add indicator to moderators

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ If you are developing locally, you need to create `.env` files in both the `apps
 | `DISCORD_CLIENT_ID`      | Client ID of the bot app                                                                                                | ✔️        |
 | `DEV_GUILD_ID`           | The ID of the Discord server to register dev commands with `yarn dev:register-commands`                                 | ❌        |
 | `PUBLIC_PROFILE_ROLE_ID` | The ID of the role to make Discord profiles public in the database                                                      | ❌        |
-| `INDEXABLE_CHANNEL_IDS`  | Comman-separated list of forum channels to index                                                                        | ✔️        |
+| `MODERATOR_ROLE_ID`      | The ID of the role to set moderator status in the database                                                              | ❌        |
+| `INDEXABLE_CHANNEL_IDS`  | Comma-separated list of forum channels to index                                                                         | ✔️        |
 | `DATABASE_URL`           | The connection string to connect to the DB                                                                              | ✔️        |
 | `REVALIDATE_SECRET`      | The same secret from the `web` project                                                                                  | ✔️        |
 | `WEB_URL`                | The address of the web service, used to make the call to revalidate the cache                                           | ✔️        |

--- a/apps/bot/env.ts
+++ b/apps/bot/env.ts
@@ -12,6 +12,7 @@ const envVars = z.object({
   DISCORD_CLIENT_ID: z.string(),
   DEV_GUILD_ID: z.string().optional(),
   PUBLIC_PROFILE_ROLE_ID: z.string().optional(),
+  MODERATOR_ROLE_ID: z.string().optional(),
   INDEXABLE_CHANNEL_IDS: z.string().transform((str) => str.split(',')),
 
   // Database

--- a/apps/bot/index.ts
+++ b/apps/bot/index.ts
@@ -131,16 +131,8 @@ client.on(Events.ThreadDelete, async (thread) => {
 })
 
 client.on(Events.GuildMemberUpdate, async (oldMember, newMember) => {
-  if (!env.PUBLIC_PROFILE_ROLE_ID) return
-
-  const hadRole = oldMember.roles.cache.has(env.PUBLIC_PROFILE_ROLE_ID)
-  const hasRole = newMember.roles.cache.has(env.PUBLIC_PROFILE_ROLE_ID)
-
-  // If the user changed the public profile role, trigger a resync
-  if ((hadRole && !hasRole) || (!hadRole && hasRole)) {
-    usersCache.delete(newMember.user.id)
-    await syncUser(newMember.user, newMember)
-  }
+  if (newMember.user.bot) return 
+  await syncUser(newMember.user, newMember)
 })
 
 client.on(Events.InteractionCreate, async (interaction) => {

--- a/apps/bot/lib/cache.ts
+++ b/apps/bot/lib/cache.ts
@@ -1,4 +1,12 @@
 import LRUCache from 'lru-cache'
 
-export const usersCache = new LRUCache<string, boolean>({ max: 100 })
+export const usersCache = new LRUCache<string, CacheUser>({ max: 100 })
 export const channelsCache = new LRUCache<string, boolean>({ max: 10 })
+
+export interface CacheUser {
+    username: string
+    discriminator: string
+    avatarUrl: string
+    isPublic?: boolean
+    isModerator?: boolean
+}

--- a/apps/web/app/post/[id]/page.tsx
+++ b/apps/web/app/post/[id]/page.tsx
@@ -54,6 +54,7 @@ const getPostMessage = async (postId: string) => {
       'users.avatarUrl as authorAvatarUrl',
       'users.username as authorUsername',
       'users.isPublic as userIsPublic',
+      'users.isModerator as userIsModerator',
       sql<Attachment[]>`
         if(
           count(attachments.id) > 0,
@@ -90,6 +91,7 @@ const getMessages = async (postId: string) => {
       'users.avatarUrl as authorAvatarUrl',
       'users.username as authorUsername',
       'users.isPublic as userIsPublic',
+      'users.isModerator as userIsModerator',
       sql<Attachment[]>`
         if(
           count(attachments.id) > 0,
@@ -242,6 +244,7 @@ const Post = async ({ params }: PostProps) => {
                   username: postMessage.authorUsername,
                   avatarUrl: postMessage.authorAvatarUrl,
                   isPublic: postMessage.userIsPublic == 1,
+                  isModerator: postMessage.userIsModerator == 1,
                 }}
                 attachments={postMessage.attachments}
                 isFirstRow
@@ -314,6 +317,7 @@ const Post = async ({ params }: PostProps) => {
                     username: message.authorUsername,
                     avatarUrl: message.authorAvatarUrl,
                     isPublic: message.userIsPublic == 1,
+                    isModerator: message.userIsModerator == 1,
                   }}
                   attachments={message.attachments}
                 />

--- a/apps/web/components/icons/shield-check.tsx
+++ b/apps/web/components/icons/shield-check.tsx
@@ -1,0 +1,17 @@
+import { IconProps, IconSvg } from './base'
+
+export const ShieldCheckIcon = (props: IconProps) => (
+  <IconSvg
+    viewBox="0 0 24 24"
+    fill="none"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
+    />
+  </IconSvg>
+)

--- a/apps/web/components/message.tsx
+++ b/apps/web/components/message.tsx
@@ -3,12 +3,13 @@ import { DisplayLocalTime } from './local-time'
 import 'highlight.js/styles/github-dark-dimmed.css'
 import { Attachment, MessageContent } from './message-content'
 import { IncognitoIcon } from './icons/incognito'
+import { ShieldCheckIcon } from './icons/shield-check'
 
 type MessageProps = {
   snowflakeId: string
   content: string
   isFirstRow: boolean
-  author: { username: string; avatarUrl: string, isPublic: boolean }
+  author: { username: string; avatarUrl: string, isPublic: boolean, isModerator: boolean }
   createdAt: Date
   attachments: Attachment[]
 }
@@ -49,9 +50,14 @@ export const Message = ({
             <div className="flex items-center space-x-2">
               <div className="font-semibold whitespace-nowrap overflow-hidden text-ellipsis">
                 {author.username}
-                {!author.isPublic && 
+                {!author.isPublic &&
                   <i title="User's profile isn't public">
-                    <IncognitoIcon className='pl-1'/>
+                    <IncognitoIcon className='pl-1' />
+                  </i>
+                }
+                {author.isModerator &&
+                  <i title="User is a moderator">
+                    <ShieldCheckIcon className='pl-1' />
                   </i>
                 }
               </div>

--- a/packages/db/migrations/1-add-moderator.ts
+++ b/packages/db/migrations/1-add-moderator.ts
@@ -1,0 +1,16 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+    // --- add moderator to users
+    await db.schema
+        .alterTable('users')
+        .addColumn('isModerator', 'boolean', (col) => col.notNull().defaultTo(false))
+        .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+    await db.schema
+        .alterTable('users')
+        .dropColumn('isModerator')
+        .execute()
+}

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -48,6 +48,7 @@ export interface Users {
   id: Generated<Buffer>;
   snowflakeId: string;
   isPublic: Generated<number>;
+  isModerator: Generated<number>;
   username: string;
   discriminator: string;
   avatarUrl: string;


### PR DESCRIPTION
Closes #21 and closes #22 

This changes the way that the bot chooses to sync a user. It changes the user cache variable and stores a basic object of the user instead of a boolean. This allows for checking if the user has changed to avoid sending an unnecessary update query. I do know that this adds more memory usage because it is another cache (along side discord.js), but I feel like it is the best method when you consider it centralizes the user change (as well as allowing a changed user object in new message).

I also added the `isModerator` column to the users table. This is only granted if the user has the moderator role (set in the new env variable `MODERATOR_ROLE_ID`). Currently, this should be given to them with a new message or profile change (once merged). Even though your original issue was for staff, your comment suggested that it was currently targeted for moderators. 

I hope that it was fine that I did 2 issues in this PR because adding moderators kind of required the sync user change.