### PR TITLE
Add internal linking

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-wrap-balancer": "^0.5.0",
-    "tailwind-merge": "^1.10.0"
+    "tailwind-merge": "^1.10.0",
+    "simple-markdown": "^0.7.3"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/apps/web/utils/discord-markdown.ts
+++ b/apps/web/utils/discord-markdown.ts
@@ -68,12 +68,12 @@ export const parseDiscordMessage = async (content: string) => {
     discordCallback: {
       user: (node) => {
         const user = users.find((u) => u.snowflakeId === node.id)
-        const userName = sanitizeText(user?.username) ?? 'Unknown User'
+        const userName = sanitizeText(user?.username ?? 'Unknown User')
         return `@${userName}`
       },
       channel: (node) => {
         const channel = channels.find((c) => c.snowflakeId === node.id)
-        const channelName = sanitizeText(channel?.name) ?? 'Unknown Channel'
+        const channelName = sanitizeText(channel?.name ?? 'Unknown Channel')
         return `#${channelName}`
       },
     },

--- a/apps/web/utils/discord-markdown.ts
+++ b/apps/web/utils/discord-markdown.ts
@@ -1,11 +1,34 @@
 import { toHTML } from 'discord-markdown'
 import { load } from 'cheerio'
 import { db } from '@nextjs-forum/db/node'
+import { getCanonicalPostUrl } from './urls'
+import { sanitizeText } from 'simple-markdown'
 
 export const parseDiscordMessage = async (content: string) => {
   // Mentions handling
   const memberIds = new Set<string>()
   const channelIds = new Set<string>()
+
+  // convert https://discord.com/channels/<guild_id>/<post_id> to https://nextjs-forum.com/posts/<post_id>
+  // or https://discord.com/channels/<guild_id>/<channel_id>/<message_id> to https://nextjs-forum.com/posts/<post_id>#message-<message_id>
+  const regex = /https:\/\/discord\.com\/channels\/(?<guild>\d+)\/(?<channel>\d+)(\/(?<message>\d+))?/g;
+  const postIds = new Set<string>(Array.from(content.matchAll(regex), (m) => m.groups?.channel ?? ''))
+
+  const posts =
+    postIds.size > 0
+      ? await db
+        .selectFrom('posts')
+        .select(['snowflakeId', 'title'])
+        .where('snowflakeId', 'in', Array.from(postIds))
+        .execute()
+      : []
+
+  // Parse the content again, this time replacing the link
+  content = content.replace(regex, (match, guild, channel, _, message) => {
+    const post = posts.find((p) => p.snowflakeId === channel)
+    if (!post) return match
+    return `${getCanonicalPostUrl(post.snowflakeId)}${message ? `#message-${message}` : ''}`
+  })
 
   // The library doesn't allow async callbacks, so we have to do this in two steps
   toHTML(content, {
@@ -25,19 +48,19 @@ export const parseDiscordMessage = async (content: string) => {
   const users =
     memberIds.size > 0
       ? await db
-          .selectFrom('users')
-          .select(['snowflakeId', 'username'])
-          .where('snowflakeId', 'in', Array.from(memberIds))
-          .execute()
+        .selectFrom('users')
+        .select(['snowflakeId', 'username'])
+        .where('snowflakeId', 'in', Array.from(memberIds))
+        .execute()
       : []
 
   const channels =
     channelIds.size > 0
       ? await db
-          .selectFrom('channels')
-          .select(['snowflakeId', 'name'])
-          .where('snowflakeId', 'in', Array.from(channelIds))
-          .execute()
+        .selectFrom('channels')
+        .select(['snowflakeId', 'name'])
+        .where('snowflakeId', 'in', Array.from(channelIds))
+        .execute()
       : []
 
   // Parse the content again, this time replacing the nodes and the rest of the stuff
@@ -45,13 +68,13 @@ export const parseDiscordMessage = async (content: string) => {
     discordCallback: {
       user: (node) => {
         const user = users.find((u) => u.snowflakeId === node.id)
-        const userName = user?.username ?? 'Unknown User'
-        return `<span class="d-mention">@${userName}</span>`
+        const userName = sanitizeText(user?.username) ?? 'Unknown User'
+        return `@${userName}`
       },
       channel: (node) => {
         const channel = channels.find((c) => c.snowflakeId === node.id)
-        const channelName = channel?.name ?? 'Unknown Channel'
-        return `<span class="d-mention">#${channelName}</span>`
+        const channelName = sanitizeText(channel?.name) ?? 'Unknown Channel'
+        return `#${channelName}`
       },
     },
   })


### PR DESCRIPTION
This coverts message links to other posts to link to their respective webpage. The method is a regex for the link  -> check if the post is in the db -> change url. This PR also fixes XSS with channel names by sanitizing it with the same [package](https://www.npmjs.com/package/simple-markdown) that [discord-markdown](https://www.npmjs.com/package/simple-markdown) uses for that purpose. I wasn't sure if you purposefully had it add `d-mention` twice, so I removed that because it looked weird around the sides.

* `https://discord.com/channels/<guild_id>/<post_id>` -> ` https://nextjs-forum.com/posts/<post_id>`
* `https://discord.com/channels/<guild_id>/<channel_id>/<message_id>` -> `https://nextjs-forum.com/posts/<post_id>#message-<message_id>`

This can be further improved with #23 because the current library doesn't provide a good method of making the channel mentions linkable.
