### PR TITLE
Better markdown support

### DIFF
--- a/apps/web/app/post/[id]/page.tsx
+++ b/apps/web/app/post/[id]/page.tsx
@@ -127,7 +127,8 @@ export const generateMetadata = async ({
   const postMessage = await getPostMessage(params.id)
 
   const title = post?.title
-  const description = truncate(postMessage?.content || '', 230)
+  const postMessageFormatted = await parseDiscordMessageBasic(postMessage?.content || '')
+  const description = truncate(postMessageFormatted, 230)
   const url = getCanonicalPostUrl(params.id)
 
   return {

--- a/apps/web/app/post/[id]/page.tsx
+++ b/apps/web/app/post/[id]/page.tsx
@@ -14,6 +14,7 @@ import { CheckCircleSolidIcon } from '@/components/icons/check-circle-solid'
 import { Attachment, MessageContent } from '@/components/message-content'
 import { ArrowDownIcon } from '@/components/icons/arrow-down'
 import type { QAPage, WithContext } from 'schema-dts'
+import { parseDiscordMessageBasic } from '@/utils/discord-markdown'
 
 const getPost = async (snowflakeId: string) => {
   return await db
@@ -173,7 +174,9 @@ const Post = async ({ params }: PostProps) => {
     mainEntity: {
       '@type': 'Question',
       name: post.title,
-      text: postMessage?.content || 'Original message was deleted.',
+      text: postMessage 
+        ? await parseDiscordMessageBasic(postMessage?.content) 
+        : 'Original message was deleted.',
       dateCreated: post.createdAt.toJSON(),
       answerCount: messages.length,
       author: {
@@ -184,7 +187,7 @@ const Post = async ({ params }: PostProps) => {
         hasAnswer && answerMessage
           ? {
               '@type': 'Answer',
-              text: answerMessage.content,
+              text: await parseDiscordMessageBasic(answerMessage.content),
               url: `${getCanonicalPostUrl(params.id)}#message-${
                 answerMessage.snowflakeId
               }`,
@@ -200,7 +203,7 @@ const Post = async ({ params }: PostProps) => {
         !hasAnswer && messages[0]
           ? {
               '@type': 'Answer',
-              text: messages[0].content,
+              text: await parseDiscordMessageBasic(messages[0].content),
               url: `${getCanonicalPostUrl(params.id)}#message-${
                 messages[0].snowflakeId
               }`,

--- a/apps/web/app/post/[id]/page.tsx
+++ b/apps/web/app/post/[id]/page.tsx
@@ -14,7 +14,7 @@ import { CheckCircleSolidIcon } from '@/components/icons/check-circle-solid'
 import { Attachment, MessageContent } from '@/components/message-content'
 import { ArrowDownIcon } from '@/components/icons/arrow-down'
 import type { QAPage, WithContext } from 'schema-dts'
-import { parseDiscordMessageBasic } from '@/utils/discord-markdown'
+import { parseDiscordMessage } from '@/utils/discord-markdown'
 
 const getPost = async (snowflakeId: string) => {
   return await db
@@ -127,7 +127,7 @@ export const generateMetadata = async ({
   const postMessage = await getPostMessage(params.id)
 
   const title = post?.title
-  const postMessageFormatted = await parseDiscordMessageBasic(postMessage?.content || '')
+  const postMessageFormatted = await parseDiscordMessage(postMessage?.content || '', true)
   const description = truncate(postMessageFormatted, 230)
   const url = getCanonicalPostUrl(params.id)
 
@@ -176,7 +176,7 @@ const Post = async ({ params }: PostProps) => {
       '@type': 'Question',
       name: post.title,
       text: postMessage 
-        ? await parseDiscordMessageBasic(postMessage?.content) 
+        ? await parseDiscordMessage(postMessage?.content, true) 
         : 'Original message was deleted.',
       dateCreated: post.createdAt.toJSON(),
       answerCount: messages.length,
@@ -188,7 +188,7 @@ const Post = async ({ params }: PostProps) => {
         hasAnswer && answerMessage
           ? {
               '@type': 'Answer',
-              text: await parseDiscordMessageBasic(answerMessage.content),
+              text: await parseDiscordMessage(answerMessage.content, true),
               url: `${getCanonicalPostUrl(params.id)}#message-${
                 answerMessage.snowflakeId
               }`,
@@ -204,7 +204,7 @@ const Post = async ({ params }: PostProps) => {
         !hasAnswer && messages[0]
           ? {
               '@type': 'Answer',
-              text: await parseDiscordMessageBasic(messages[0].content),
+              text: await parseDiscordMessage(messages[0].content, true),
               url: `${getCanonicalPostUrl(params.id)}#message-${
                 messages[0].snowflakeId
               }`,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,8 @@
     "react-dom": "^18.2.0",
     "react-wrap-balancer": "^0.5.0",
     "tailwind-merge": "^1.10.0",
-    "simple-markdown": "^0.7.3"
+    "simple-markdown": "^0.7.3",
+    "lru-cache": "^8.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,8 +21,7 @@
     "react-dom": "^18.2.0",
     "react-wrap-balancer": "^0.5.0",
     "tailwind-merge": "^1.10.0",
-    "simple-markdown": "^0.7.3",
-    "lru-cache": "^8.0.4"
+    "simple-markdown": "^0.7.3"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/apps/web/utils/discord-markdown.ts
+++ b/apps/web/utils/discord-markdown.ts
@@ -150,7 +150,7 @@ export const parseDiscordMessage = async (content: string) => {
     discordCallback: {
       user: (node) => {
         const user = users.find((u) => u.snowflakeId === node.id)
-        if (!user) return `<i>@Unknown Channel</i>`
+        if (!user) return `<i>@Unknown User</i>`
         const userName = sanitizeText(user.username)
         return `@${userName}`
       },
@@ -159,7 +159,7 @@ export const parseDiscordMessage = async (content: string) => {
         let channelName = channel && sanitizeText(channel.name)
         if (!channelName) {
           const post = posts.find((p) => p.snowflakeId === node.id)
-          channelName = post ? sanitizeText(post.title) : '<i>#Unknown User</i>'
+          channelName = post ? sanitizeText(post.title) : '<i>#Unknown Channel</i>'
         }
         return `#${channelName}`
       },

--- a/apps/web/utils/discord-markdown.ts
+++ b/apps/web/utils/discord-markdown.ts
@@ -3,77 +3,164 @@ import { load } from 'cheerio'
 import { db } from '@nextjs-forum/db/node'
 import { getCanonicalPostUrl } from './urls'
 import { sanitizeText } from 'simple-markdown'
+import LRUCache from 'lru-cache'
+
+
+const userCache = new LRUCache<string, UserCache>({ max: 15, ttl: 1000 * 60 })
+const channelCache = new LRUCache<string, ChannelCache>({ max: 15, ttl: 1000 * 60 })
+const postCache = new LRUCache<string, PostCache>({ max: 15, ttl: 1000 * 60 })
+
+interface UserCache {
+  snowflakeId: string
+  username: string
+}
+
+interface ChannelCache {
+  snowflakeId: string
+  name: string
+}
+
+interface PostCache {
+  snowflakeId: string
+  title: string
+}
+
+const fetchUser = async (userId: string) => {
+  const user = userCache.get(userId)
+  if (user) return user
+
+  const dbUser = await db
+    .selectFrom('users')
+    .select(['snowflakeId', 'username'])
+    .where('snowflakeId', '=', userId)
+    .executeTakeFirst()
+
+  if (!dbUser) return null
+  userCache.set(userId, dbUser)
+  return dbUser
+}
+
+const fetchChannel = async (channelId: string) => {
+  const channel = channelCache.get(channelId)
+  if (channel) return channel
+
+  const dbChannel = await db
+    .selectFrom('channels')
+    .select(['snowflakeId', 'name'])
+    .where('snowflakeId', '=', channelId)
+    .executeTakeFirst()
+
+  if (!dbChannel) return null
+  channelCache.set(channelId, dbChannel)
+  return dbChannel
+}
+
+const fetchPost = async (postId: string) => {
+  const post = postCache.get(postId)
+  if (post) return post
+
+  const dbPost = await db
+    .selectFrom('posts')
+    .select(['snowflakeId', 'title'])
+    .where('snowflakeId', '=', postId)
+    .executeTakeFirst()
+
+  if (!dbPost) return null
+  postCache.set(postId, dbPost)
+  return dbPost
+}
+
+const linkRegex = /https:\/\/discord\.com\/channels\/(?<guild>\d+)\/(?<channel>\d+)(\/(?<message>\d+))?/g;
+const userMention = /<@!?(?<user>\d+)>/g;
+const channelMention = /<#(?<channel>\d+)>/g;
+
+export const extractMentions = (content: string) => {
+  const postIds = new Set<string>(Array.from(content.matchAll(linkRegex), (m) => m.groups?.channel ?? ''))
+  const memberIds = new Set<string>(Array.from(content.matchAll(userMention), (m) => m.groups?.user ?? ''))
+  const channelIds = new Set<string>(Array.from(content.matchAll(channelMention), (m) => m.groups?.channel ?? ''))
+  return { postIds, memberIds, channelIds }
+}
+
+export const fetchMentions = async (content: string) => {
+  const { postIds, memberIds, channelIds } = extractMentions(content)
+
+  // Fetch from db/cache
+  const [posts, users, channels] = (await Promise.all([
+    Promise.all(Array.from(postIds).map(fetchPost)),
+    Promise.all(Array.from(memberIds).map(fetchUser)),
+    Promise.all(Array.from(channelIds).map(fetchChannel)),
+  ]))
+
+  // Filter out null values
+  const postsFiltered = posts.filter((p) => p !== null) as PostCache[]
+  const usersFiltered = users.filter((u) => u !== null) as UserCache[]
+  const channelsFiltered = channels.filter((c) => c !== null) as ChannelCache[]
+
+  return { posts: postsFiltered, users: usersFiltered, channels: channelsFiltered }
+}
+
+const internalLink = (content: string, posts: PostCache[]) => {
+  // Replace internal links
+  content = content.replace(linkRegex, (match, guildId, channelId, _, messageId) => {
+    const post = posts.find((p) => p.snowflakeId === channelId)
+    if (!post) return match
+    return `${getCanonicalPostUrl(post.snowflakeId)}${messageId ? `#message-${messageId}` : ''}`
+  })
+  return content
+}
+
+export const parseDiscordMessageBasic = async (content: string) => {
+  // Get mentions
+  const { users, channels, posts } = await fetchMentions(content)
+
+  // Replace user mentions
+  content = content.replace(userMention, (match, userId) => {
+    const member = users.find((u) => u.snowflakeId === userId)
+    const userName = sanitizeText(member?.username ?? 'Unknown User')
+    return `@${userName}`
+  })
+
+  // Replace channel mentions
+  content = content.replace(channelMention, (match, channelId) => {
+    const channel = channels.find((c) => c.snowflakeId === channelId)
+
+    let channelName = channel && sanitizeText(channel.name)
+    if (!channelName) {
+      const post = posts.find((p) => p.snowflakeId === channelId)
+      channelName = post ? sanitizeText(post.title) : 'Unknown Channel'
+    }
+    return `#${channelName}`
+  })
+
+  // Replace internal links
+  content = internalLink(content, posts)
+
+  return content
+}
 
 export const parseDiscordMessage = async (content: string) => {
-  // Mentions handling
-  const memberIds = new Set<string>()
-  const channelIds = new Set<string>()
+  // Get mentions
+  const { users, channels, posts } = await fetchMentions(content)
 
-  // convert https://discord.com/channels/<guild_id>/<post_id> to https://nextjs-forum.com/posts/<post_id>
-  // or https://discord.com/channels/<guild_id>/<channel_id>/<message_id> to https://nextjs-forum.com/posts/<post_id>#message-<message_id>
-  const regex = /https:\/\/discord\.com\/channels\/(?<guild>\d+)\/(?<channel>\d+)(\/(?<message>\d+))?/g;
-  const postIds = new Set<string>(Array.from(content.matchAll(regex), (m) => m.groups?.channel ?? ''))
+  // Replace internal links
+  content = internalLink(content, posts)
 
-  const posts =
-    postIds.size > 0
-      ? await db
-        .selectFrom('posts')
-        .select(['snowflakeId', 'title'])
-        .where('snowflakeId', 'in', Array.from(postIds))
-        .execute()
-      : []
-
-  // Parse the content again, this time replacing the link
-  content = content.replace(regex, (match, guild, channel, _, message) => {
-    const post = posts.find((p) => p.snowflakeId === channel)
-    if (!post) return match
-    return `${getCanonicalPostUrl(post.snowflakeId)}${message ? `#message-${message}` : ''}`
-  })
-
-  // The library doesn't allow async callbacks, so we have to do this in two steps
-  toHTML(content, {
-    discordOnly: true,
-    discordCallback: {
-      user(node) {
-        memberIds.add(node.id)
-        return ''
-      },
-      channel(node) {
-        channelIds.add(node.id)
-        return ''
-      },
-    },
-  })
-
-  const users =
-    memberIds.size > 0
-      ? await db
-        .selectFrom('users')
-        .select(['snowflakeId', 'username'])
-        .where('snowflakeId', 'in', Array.from(memberIds))
-        .execute()
-      : []
-
-  const channels =
-    channelIds.size > 0
-      ? await db
-        .selectFrom('channels')
-        .select(['snowflakeId', 'name'])
-        .where('snowflakeId', 'in', Array.from(channelIds))
-        .execute()
-      : []
-
-  // Parse the content again, this time replacing the nodes and the rest of the stuff
+  // Parse the content
   const html = toHTML(content, {
     discordCallback: {
       user: (node) => {
         const user = users.find((u) => u.snowflakeId === node.id)
-        const userName = sanitizeText(user?.username ?? 'Unknown User')
+        if (!user) return `<i>@Unknown Channel</i>`
+        const userName = sanitizeText(user.username)
         return `@${userName}`
       },
       channel: (node) => {
         const channel = channels.find((c) => c.snowflakeId === node.id)
-        const channelName = sanitizeText(channel?.name ?? 'Unknown Channel')
+        let channelName = channel && sanitizeText(channel.name)
+        if (!channelName) {
+          const post = posts.find((p) => p.snowflakeId === node.id)
+          channelName = post ? sanitizeText(post.title) : '<i>#Unknown User</i>'
+        }
         return `#${channelName}`
       },
     },


### PR DESCRIPTION
Closes #43 

This builds upon #50 and separates out the many functions involved to allow for a basic (for metatags) and still have the more advanced main message view. I made use of `unstable_cache` (it seemed trustworthy enough) to cache result of the mentions which should also allow for mentions to not need to be re-fetched in the same thread. I also decided to not keep your bulk query because it didn't seem like many of the same mention type would occur at the same time.

The next step with improving this is #23 and some other way that allows for the channel mentions to be a link.