### PR TITLE
Update `text` datetime to the following format: "17 Sep 2023 at 15:20"

### DIFF
--- a/apps/web/components/post.tsx
+++ b/apps/web/components/post.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 import plur from 'plur'
 import { buildPostTimeValues } from '@/utils/datetime'
-import { DisplayLocalTime } from './local-time'
 
 type PostProps = {
   id: string
@@ -44,7 +43,7 @@ export const Post = ({
           <div className="text-sm opacity-90 no-underline">
             {author.username} asked on{' '}
             <time dateTime={createdAtTimes.iso} title={createdAtTimes.tooltip}>
-              <DisplayLocalTime dateStr={createdAt.toISOString()} />
+              {createdAtTimes.text}
             </time>{' '}
             · {messagesCount} {plur('Message', messagesCount)}
             {hasAnswer && (

--- a/apps/web/components/post.tsx
+++ b/apps/web/components/post.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import plur from 'plur'
 import { buildPostTimeValues } from '@/utils/datetime'
+import { DisplayLocalTime } from './local-time'
 
 type PostProps = {
   id: string
@@ -43,7 +44,7 @@ export const Post = ({
           <div className="text-sm opacity-90 no-underline">
             {author.username} asked on{' '}
             <time dateTime={createdAtTimes.iso} title={createdAtTimes.tooltip}>
-              {createdAtTimes.text}
+              <DisplayLocalTime dateStr={createdAt.toISOString()} />
             </time>{' '}
             · {messagesCount} {plur('Message', messagesCount)}
             {hasAnswer && (

--- a/apps/web/utils/datetime.ts
+++ b/apps/web/utils/datetime.ts
@@ -2,21 +2,27 @@ import { DateTime } from '@/utils/luxon'
 
 export const buildPostTimeValues = (createdAt: Date) => {
   const datetime = DateTime.fromJSDate(createdAt)
-  const text = datetime.toLocaleString(DateTime.DATETIME_SHORT)
-  const shortText = datetime.toLocaleString({
-    hour: 'numeric',
-    minute: 'numeric',
-  })
-  const tooltip = datetime.toLocaleString({
+  const text = datetime.setLocale('en-GB').toLocaleString({
     year: 'numeric',
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
     minute: 'numeric',
+  }) // 17 Sep 2023 at 15:20
+  const shortText = datetime.toLocaleString({
+    hour: 'numeric',
+    minute: 'numeric',
+  }) // 15:20
+  const tooltip = datetime.setLocale('en-GB').toLocaleString({
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
     second: 'numeric',
     timeZoneName: 'short',
-  })
-  const iso = datetime.toISO()
+  }) // 17 September 2023 at 15:20:38 GMT+7
+  const iso = datetime.toISO() // 2023-09-17T15:20:38.000+07:00
 
   return { text, shortText, tooltip, iso }
 }

--- a/apps/web/utils/datetime.ts
+++ b/apps/web/utils/datetime.ts
@@ -1,14 +1,8 @@
 import { DateTime } from '@/utils/luxon'
 
-export const formatPostDate = (date: DateTime) => {
-  return DateTime.now().year === date.year
-    ? date.toLocaleString({ month: 'short', day: 'numeric' })
-    : date.toLocaleString({ year: 'numeric', month: 'short', day: 'numeric' })
-}
-
 export const buildPostTimeValues = (createdAt: Date) => {
   const datetime = DateTime.fromJSDate(createdAt)
-  const text = formatPostDate(datetime)
+  const text = datetime.toLocaleString(DateTime.DATETIME_SHORT)
   const shortText = datetime.toLocaleString({
     hour: 'numeric',
     minute: 'numeric',


### PR DESCRIPTION
~~It is now "9/1/2023, 4:07 PM" not "Sep 1". Though should we make it something like "Sep 1, 2023, 4:07 PM"?~~

<img width="363" alt="image" src="https://github.com/rafaelalmeidatk/nextjs-forum/assets/44609036/1b0e953e-358e-41d8-9afd-93135771928c">

Closes #16.
