### PR TITLE
Add `lastActiveAt` row to `posts` table

### DIFF
--- a/apps/bot/commands/context/mark-answer.ts
+++ b/apps/bot/commands/context/mark-answer.ts
@@ -16,6 +16,7 @@ import {
 } from '../../utils.js'
 import { markMessageAsSolution } from '../../db/actions/messages.js'
 import { env } from '../../env.js'
+import { updatePostLastActive } from '../../db/actions/posts.js'
 
 export const command: ContextMenuCommand = {
   data: new ContextMenuCommandBuilder()
@@ -102,6 +103,8 @@ export const command: ContextMenuCommand = {
       interaction.targetMessage.id,
       interaction.channelId,
     )
+
+    await updatePostLastActive(interaction.channelId)
 
     const answeredTagId = mainChannel.availableTags.find((t) =>
       t.name.includes('Answered'),

--- a/apps/bot/commands/slash/index.ts
+++ b/apps/bot/commands/slash/index.ts
@@ -1,7 +1,9 @@
 import * as refreshAnswerCount from './refresh-answer-count.js'
+import * as refreshLastActive from './refresh-last-active.js'
 import * as lockLowEffortPost from './lock-low-effort-post.js'
 
 export const slashCommands = [
   refreshAnswerCount.command,
+  refreshLastActive.command,
   lockLowEffortPost.command,
 ]

--- a/apps/bot/commands/slash/refresh-last-active.ts
+++ b/apps/bot/commands/slash/refresh-last-active.ts
@@ -1,0 +1,68 @@
+import { Colors, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js'
+import { SlashCommand } from '../types.js'
+import { replyWithEmbed } from '../../utils.js'
+import { db, sql } from '@nextjs-forum/db/node'
+
+export const command: SlashCommand = {
+  data: new SlashCommandBuilder()
+    .setName('refresh-last-active')
+    .setDescription(
+      'Refreshes the last active time for every post (expensive call so only use it if really necessary)',
+    )
+    .setDMPermission(false)
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+
+  async execute(interaction) {
+    await replyWithEmbed(interaction, {
+      title: '⌛ Processing...',
+      description:
+        'Your request has been queued. This might take a while to complete...',
+    })
+
+    try {
+      // update posts with lastmod time
+      const posts = await db
+        .selectFrom('posts')
+        .select([
+          'posts.snowflakeId',
+          sql<Date>`MAX(IFNULL(posts.editedAt, posts.createdAt))`.as('lastModTime'),
+          sql<Date>`MAX(IFNULL(messages.editedAt, messages.createdAt))`.as(
+            'lastMessageModTime',
+          ),
+        ])
+        .leftJoin('messages', 'posts.snowflakeId', 'messages.postId')
+        .groupBy('posts.snowflakeId')
+        .execute()
+
+      for (const post of posts) {
+        const lastActive = post.lastMessageModTime > post.lastModTime ? post.lastMessageModTime : post.lastModTime
+        db
+          .updateTable('posts')
+          .where('posts.snowflakeId', '=', post.snowflakeId)
+          .set({ lastActiveAt: lastActive })
+          .execute()
+      }
+
+      await interaction.editReply({
+        embeds: [
+          {
+            title: '✅ Success!',
+            description: 'The answer count of the users has been updated',
+            color: Colors.Green,
+          },
+        ],
+      })
+    } catch (err) {
+      const description = err instanceof Error ? err.message : 'Unknown reason'
+
+      await interaction.editReply({
+        embeds: [
+          {
+            title: 'Error',
+            description,
+          },
+        ],
+      })
+    }
+  },
+}

--- a/apps/bot/db/actions/posts.ts
+++ b/apps/bot/db/actions/posts.ts
@@ -14,13 +14,13 @@ export const syncPost = async (thread: AnyThreadChannel) => {
       isLocked: thread.locked ? 1 : 0,
       userId: thread.ownerId,
       channelId: thread.parentId,
-      lastActiveAt: new Date()
+      lastActiveAt: now
     })
     .onDuplicateKeyUpdate({
       title: thread.name,
       editedAt: now,
       isLocked: thread.locked ? 1 : 0,
-      lastActiveAt: new Date()
+      lastActiveAt: now
     })
     .executeTakeFirst()
 

--- a/apps/bot/db/actions/posts.ts
+++ b/apps/bot/db/actions/posts.ts
@@ -1,6 +1,6 @@
 import { AnyThreadChannel } from 'discord.js'
 import { db } from '@nextjs-forum/db/node'
-import { revalidateHomePage, revalidateSitemap } from '../../revalidate.js'
+import { revalidateHomePage } from '../../revalidate.js'
 
 export const syncPost = async (thread: AnyThreadChannel) => {
   const now = new Date()
@@ -38,7 +38,4 @@ export const updatePostLastActive = async (postId: string) => {
     .where('snowflakeId', '=', postId)
     .set({ lastActiveAt: new Date() })
     .execute()
-
-  // revalidate sitemap (its the only thing using the last active data)
-  await revalidateSitemap()
 }

--- a/apps/bot/index.ts
+++ b/apps/bot/index.ts
@@ -2,7 +2,7 @@ import { Colors, Events, GatewayIntentBits, Partials, Client } from 'discord.js'
 import { dedent } from 'ts-dedent'
 import { env } from './env.js'
 import { deleteMessage, syncMessage } from './db/actions/messages.js'
-import { deletePost, syncPost } from './db/actions/posts.js'
+import { deletePost, syncPost, updatePostLastActive } from './db/actions/posts.js'
 import { baseLog } from './log.js'
 import {
   isMessageInForumChannel,
@@ -38,6 +38,7 @@ client.on(Events.MessageCreate, async (message) => {
 
   try {
     await syncMessage(message)
+    await updatePostLastActive(message.channelId)
     baseLog('Created a new message in post %s', message.channelId)
   } catch (err) {
     console.error('Failed to create message:', err)
@@ -52,6 +53,7 @@ client.on(Events.MessageUpdate, async (_, newMessage) => {
     if (!isMessageSupported(message)) return
 
     await syncMessage(message)
+    await updatePostLastActive(message.channelId)
     baseLog('Updated a message in post %s', message.channelId)
   } catch (err) {
     console.error('Failed to update message:', err)
@@ -63,6 +65,7 @@ client.on(Events.MessageDelete, async (message) => {
 
   try {
     await deleteMessage(message.id)
+    await updatePostLastActive(message.channelId)
     baseLog('Deleted a message in post %s', message.channelId)
   } catch (err) {
     console.error('Failed to delete message:', err)

--- a/apps/bot/revalidate.ts
+++ b/apps/bot/revalidate.ts
@@ -15,7 +15,3 @@ export const revalidateHomePage = () => {
     post('/api/revalidate-sitemap'),
   ])
 }
-
-export const revalidateSitemap = () => {
-  return post('/api/revalidate-sitemap')
-}

--- a/apps/bot/revalidate.ts
+++ b/apps/bot/revalidate.ts
@@ -15,3 +15,7 @@ export const revalidateHomePage = () => {
     post('/api/revalidate-sitemap'),
   ])
 }
+
+export const revalidateSitemap = () => {
+  return post('/api/revalidate-sitemap')
+}

--- a/packages/db/migrations/3-add-last-active-to-post.ts
+++ b/packages/db/migrations/3-add-last-active-to-post.ts
@@ -1,0 +1,12 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('posts')
+    .addColumn('lastActiveAt', 'datetime', (col) => col.notNull().defaultTo(sql`now()`))
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.alterTable('posts').dropColumn('lastActiveAt').execute()
+}

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -38,6 +38,7 @@ export interface Posts {
   title: string
   isLocked: number
   createdAt: Date
+  lastActiveAt: Date
   editedAt: Date | null
   userId: string | null
   channelId: string | null


### PR DESCRIPTION
This basicly moves the last active from sitemap file to a command on the bot which the DB now stores the value persistently. This should improve speed of producing sitemap as well as less reads.

Things that could be changed:
* revalidate sitemap when active time changes may be way unnecessary as it basically could get never cached in peek times, and so many requests to the server... so, with further consideration, it may be better to make an api route to revalidate the post page and that also does the sitemap (prob out of this pr tho) **edit: i just removed the revalidate request of sitemap because of above reasons...**