### PR TITLE
Add HELPER_ROLE_ID to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ If you are developing locally, you need to create `.env` files in both the `apps
 | `DISCORD_CLIENT_ID`      | Client ID of the bot app                                                                                                | ✔️        |
 | `DEV_GUILD_ID`           | The ID of the Discord server to register dev commands with `yarn dev:register-commands`                                 | ❌        |
 | `PUBLIC_PROFILE_ROLE_ID` | The ID of the role to make Discord profiles public in the database                                                      | ❌        |
-| `MODERATOR_ROLE_ID`      | The ID of the role to set moderator status in the database                                                              | ❌        |
+| `HELPER_ROLE_ID`         | The ID of the role that allows for selecting answer on behalf of owner                                                  | ❌        |
+| `MODERATOR_ROLE_ID`      | The ID of the role to set moderator status in the database (also can select answer)                                     | ❌        |
 | `INDEXABLE_CHANNEL_IDS`  | Comma-separated list of forum channels to index                                                                         | ✔️        |
 | `DATABASE_URL`           | The connection string to connect to the DB                                                                              | ✔️        |
 | `REVALIDATE_SECRET`      | The same secret from the `web` project                                                                                  | ✔️        |


### PR DESCRIPTION
I wasn't sure what description to put, but I felt that it was important to mention the [`HELPER_ROLE_ID`](https://github.com/rafaelalmeidatk/nextjs-forum/blob/main/apps/bot/env.ts) in the README.