### PR TITLE
Fix: Long nick responsibility

### DIFF
--- a/apps/web/app/user/[discordID]/page.tsx
+++ b/apps/web/app/user/[discordID]/page.tsx
@@ -143,8 +143,8 @@ const UserInfo = async ({ params }: UserProps) => {
             src={userData.avatarUrl}
             alt={`User Avatar of ${userData.username}`}
           />
-          <div className="w-fit   h-auto flex flex-col items-start justify-start gap-1 ">
-            <h1 className="text-xl md:text-2xl font-semibold text-white line-clamp-1">
+          <div className="w-fit h-auto flex flex-col items-start justify-start gap-1 max-w-[200px]">
+            <h1 className="w-full text-xl md:text-2xl font-semibold text-white line-clamp-1">
               {userData.username}
             </h1>
             {userData.leaderBoardPosition && (

--- a/apps/web/components/most-helpful.tsx
+++ b/apps/web/components/most-helpful.tsx
@@ -39,7 +39,7 @@ export const MostHelpful = async () => {
               />
               {user.isPublic ? (
                 <Link
-                  className="opacity-90 text-white"
+                  className="opacity-90 text-white line-clamp-1 max-w-[200px]"
                   href={`/user/${user.userID}`}
                 >
                   {user.username}


### PR DESCRIPTION
Fixes a design but I noticed in random thread with a person that has long name:
- https://nextjs-forum.com/post/1323271806496411648
- https://nextjs-forum.com/user/890486507872342027


Before:
![CleanShot 2024-12-30 at 14 27 31@2x](https://github.com/user-attachments/assets/000876a8-3380-4ea6-9b2e-915182bd90d9)

After:

![CleanShot 2024-12-30 at 14 29 30@2x](https://github.com/user-attachments/assets/b886ec25-7c67-40fb-ae90-62a02fed17e9)

---


Before:

![CleanShot 2024-12-30 at 14 27 16@2x](https://github.com/user-attachments/assets/ed92dc77-fb67-4539-8b63-ca68077b6d7d)

After:


![CleanShot 2024-12-30 at 14 27 11@2x](https://github.com/user-attachments/assets/aef48431-e870-4d48-9d23-fb2d37033d21)
