### PR TITLE
Handle Errors on Avatars not being valid

### DIFF
--- a/apps/web/components/most-helpful.tsx
+++ b/apps/web/components/most-helpful.tsx
@@ -1,6 +1,7 @@
 import { db } from '@nextjs-forum/db/node'
 import { CheckCircleSolidIcon } from '@/components/icons/check-circle-solid'
 import Link from 'next/link'
+import { UserAvatar } from '@/components/user-avatar.client'
 
 const getMostHelpfulUsers = async () => {
   return db
@@ -32,10 +33,10 @@ export const MostHelpful = async () => {
         {users.map((user) => (
           <div key={user.id} className="flex justify-between py-2">
             <div className="flex space-x-2 items-center">
-              <img
+              <UserAvatar
+                className="w-4 h-4 rounded-full"
                 src={user.avatarUrl}
                 alt="Avatar"
-                className="w-4 h-4 rounded-full"
               />
               {user.isPublic ? (
                 <Link

--- a/apps/web/components/most-helpful.tsx
+++ b/apps/web/components/most-helpful.tsx
@@ -32,15 +32,15 @@ export const MostHelpful = async () => {
       <div className="mt-2 grid grid-cols-1 divide-y divide-neutral-800">
         {users.map((user) => (
           <div key={user.id} className="flex justify-between py-2">
-            <div className="flex space-x-2 items-center">
+            <div className="flex items-center space-x-2">
               <UserAvatar
-                className="w-4 h-4 rounded-full"
+                className="h-4 w-4 rounded-full"
                 src={user.avatarUrl}
                 alt="Avatar"
               />
               {user.isPublic ? (
                 <Link
-                  className="opacity-90 text-white line-clamp-1 max-w-[200px]"
+                  className="line-clamp-1 max-w-[200px] text-white opacity-90"
                   href={`/user/${user.userID}`}
                 >
                   {user.username}
@@ -51,7 +51,7 @@ export const MostHelpful = async () => {
             </div>
             <div className="flex items-center space-x-1 opacity-90">
               <CheckCircleSolidIcon size={5} />
-              <span className="text-sm ">{user.answersCount}</span>
+              <span className="text-sm">{user.answersCount}</span>
             </div>
           </div>
         ))}

--- a/apps/web/components/post.tsx
+++ b/apps/web/components/post.tsx
@@ -29,19 +29,19 @@ export const Post = ({
   return (
     <Link href={`/post/${id}`} className="block text-white no-underline">
       <div
-        className={`px-4 py-3 border bg-neutral-800 ${borderColor} rounded hover:opacity-90`}
+        className={`border bg-neutral-800 px-4 py-3 ${borderColor} rounded hover:opacity-90`}
       >
-        <p className="text-white inline-block pr-2 text-lg font-semibold">
+        <p className="inline-block pr-2 text-lg font-semibold text-white">
           {title}
         </p>
 
         <div className="mt-2 flex items-center space-x-2">
           <UserAvatar
-            className="rounded-full w-5 h-5"
+            className="h-5 w-5 rounded-full"
             src={author.avatar}
             alt={`${author.username}'s avatar`}
           />
-          <div className="text-sm opacity-90 no-underline">
+          <div className="text-sm no-underline opacity-90">
             {author.username} asked on{' '}
             <time dateTime={createdAtTimes.iso} title={createdAtTimes.tooltip}>
               {createdAtTimes.text}

--- a/apps/web/components/post.tsx
+++ b/apps/web/components/post.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import plur from 'plur'
 import { buildPostTimeValues } from '@/utils/datetime'
+import { UserAvatar } from '@/components/user-avatar.client'
 
 type PostProps = {
   id: string
@@ -35,10 +36,10 @@ export const Post = ({
         </p>
 
         <div className="mt-2 flex items-center space-x-2">
-          <img
+          <UserAvatar
+            className="rounded-full w-5 h-5"
             src={author.avatar}
             alt={`${author.username}'s avatar`}
-            className="rounded-full w-5 h-5"
           />
           <div className="text-sm opacity-90 no-underline">
             {author.username} asked on{' '}

--- a/apps/web/components/user-avatar.client.tsx
+++ b/apps/web/components/user-avatar.client.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { ImgHTMLAttributes } from 'react'
+import React from 'react'
+export function UserAvatar({
+  ...props
+}: {} & ImgHTMLAttributes<HTMLImageElement>) {
+  return (
+    <img
+      onError={(e) => {
+        const url = 'https://cdn.discordapp.com/embed/avatars/1.png'
+        e.currentTarget.src = url
+      }}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
This PR fixes the following issue
#89 

We use a client component to handle any error events, and render a default discord avatar. This makes the forum not penalize any broken PFP's due to a helper not being active on the forum. 