### PR TITLE
Small performance improvements

### DIFF
--- a/apps/web/components/most-helpful.tsx
+++ b/apps/web/components/most-helpful.tsx
@@ -41,6 +41,7 @@ export const MostHelpful = async () => {
                 <Link
                   className="opacity-90 text-white line-clamp-1 max-w-[200px]"
                   href={`/user/${user.userID}`}
+                  prefetch={false}
                 >
                   {user.username}
                 </Link>

--- a/packages/db/migrations/7-snowflake-varchar-to-text.ts
+++ b/packages/db/migrations/7-snowflake-varchar-to-text.ts
@@ -1,0 +1,71 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('attachments')
+    .alterColumn('messageId', (col) => col.setDataType('text'))
+    .alterColumn('snowflakeId', (col) => col.setDataType('text'))
+    .execute()
+
+  await db.schema
+    .alterTable('channels')
+    .alterColumn('snowflakeId', (col) => col.setDataType('text'))
+    .execute()
+
+  await db.schema
+    .alterTable('messages')
+    .alterColumn('postId', (col) => col.setDataType('text'))
+    .alterColumn('replyToMessageId', (col) => col.setDataType('text'))
+    .alterColumn('snowflakeId', (col) => col.setDataType('text'))
+    .alterColumn('userId', (col) => col.setDataType('text'))
+    .execute()
+
+  await db.schema
+    .alterTable('posts')
+    .alterColumn('answerId', (col) => col.setDataType('text'))
+    .alterColumn('channelId', (col) => col.setDataType('text'))
+    .alterColumn('snowflakeId', (col) => col.setDataType('text'))
+    .alterColumn('userId', (col) => col.setDataType('text'))
+    .execute()
+
+  await db.schema
+    .alterTable('users')
+    .alterColumn('discriminator', (col) => col.setDataType('text'))
+    .alterColumn('snowflakeId', (col) => col.setDataType('text'))
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('attachments')
+    .alterColumn('messageId', (col) => col.setDataType('varchar(40)'))
+    .alterColumn('snowflakeId', (col) => col.setDataType('varchar(40)'))
+    .execute()
+
+  await db.schema
+    .alterTable('channels')
+    .alterColumn('snowflakeId', (col) => col.setDataType('varchar(40)'))
+    .execute()
+
+  await db.schema
+    .alterTable('messages')
+    .alterColumn('postId', (col) => col.setDataType('varchar(40)'))
+    .alterColumn('replyToMessageId', (col) => col.setDataType('varchar(40)'))
+    .alterColumn('snowflakeId', (col) => col.setDataType('varchar(40)'))
+    .alterColumn('userId', (col) => col.setDataType('varchar(40)'))
+    .execute()
+
+  await db.schema
+    .alterTable('posts')
+    .alterColumn('answerId', (col) => col.setDataType('varchar(40)'))
+    .alterColumn('channelId', (col) => col.setDataType('varchar(40)'))
+    .alterColumn('snowflakeId', (col) => col.setDataType('varchar(40)'))
+    .alterColumn('userId', (col) => col.setDataType('varchar(40)'))
+    .execute()
+
+  await db.schema
+    .alterTable('users')
+    .alterColumn('discriminator', (col) => col.setDataType('varchar(4)'))
+    .alterColumn('snowflakeId', (col) => col.setDataType('varchar(40)'))
+    .execute()
+}


### PR DESCRIPTION
- Disabled prefetch for users page since it has some heavy queries
- Changed the data type of all snowflakes to `text`, both types are internally handled as text by Postgres so this makes the analyzes of queries cleaner by dropping the automatic type cast